### PR TITLE
add browser.d.ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # Typed node-uuid
 
-Typings definitions for [node-uuid](https://github.com/broofa/node-uuid).
+[Typings](https://github.com/typings/typings) definitions for [node-uuid](https://github.com/broofa/node-uuid).
+
+## Usage
+
+```
+typings install github:rapropos/typed-node-uuid --save
+```
 
 ## License
 


### PR DESCRIPTION
Hello @rapropos,

Thank you for creating these typings. I noticed that you removed the `browser.d.ts` in the previous commit probably because it was a duplicate of `node.d.ts`. But it turns out that not having a reference to the `browser` in the `typings.json` causes the `typings` command to assume that the `main` is the `browser`. Here are the actual outputs:

**Before this PR**:
Without a `browser` reference in `typings.json`

```
{
  "name": "node-uuid",
  "main": "node.d.ts",
  "dependencies": {}
}
```

the output of `typings install ...` looks like the following:

```
typings
├── [drwxr-xr-x  136]  main/
│   ├── [drwxr-xr-x  272]  ambient/
│   ├── [drwxr-xr-x  272]  definitions/    ## The empty main tree is the problem
├── [drwxr-xr-x  136]  browser/
│   └── [drwxr-xr-x  102]  node-uuid/
│       └── [-rw-r--r-- 1.2K]  node-uuid.d.ts
├── [-rw-r--r--  459]  main.d.ts
└── [-rw-r--r--  254]  tsd.json
```

**After this PR**: 
With the `browser` reference in `typings.json`

```
{
  "name": "node-uuid",
  "main": "node.d.ts",
  "browser": "node.d.ts",
  "dependencies": {}
}
```

the output of `typings install ...` looks like:

```
typings
├── [drwxr-xr-x  102]  custom/
│   └── [-rw-r--r--  166]  pool-redis-promise.d.ts
├── [drwxr-xr-x  136]  main/
│   ├── [drwxr-xr-x  272]  ambient/
│   └── [drwxr-xr-x  102]  definitions/    ## Yay!
│       └── [drwxr-xr-x  102]  node-uuid/
│           └── [-rw-r--r-- 1.2K]  node-uuid.d.ts
├── [drwxr-xr-x  136]  browser/
│   └── [drwxr-xr-x  102]  node-uuid/
│       └── [-rw-r--r-- 1.2K]  node-uuid.d.ts
├── [-rw-r--r--  459]  main.d.ts
└── [-rw-r--r--  254]  tsd.json
```

To prevent duplicated `.d.ts` we can simply reference both `main` and `browser` to the same `.d.ts` since in our case they are the same. Would like to hear your thoughts on this.

For reference:

```
$ typings --version
0.6.8
$ tsc --version
message TS6029: Version 1.7.5
```
